### PR TITLE
Reformat settings to table and add Material Type

### DIFF
--- a/controllers/api/settingRoutes.js
+++ b/controllers/api/settingRoutes.js
@@ -4,38 +4,17 @@ const withAuth = require('../../utils/auth');
 
 router.get('/', withAuth, async (req, res) => {
   try {
-   
+    const materialData = await Material.findAll();
+    const materials = materialData.map( (material) => material.get( {material : true}))
+    const materialsArr = materials.map( (material) => material.materialType)
+
     const allSettings = await Settings.findAll({
       where:{
         userId: req.session.user_id
       },
       include:[Printer, Filament]
-      //include:[Printer, Filament, Material]
-      //   include: [{
-      //   model: Printer,
-      //   as: 'printer',
-      //   include: [{
-      //     model: Filament,
-      //     as: 'filament',
-      //   }]
-      // }]
     });
-    //console.log(allSettings)
-    //console.log(allSettings.dataValues.printTemperature)
-    //console.log("foo")
-    /*const settings = allSettings.map((setting) => {
-      return {
-        "printTemperature" : setting.printTemperature,
-        "initialLayerTemperature": setting.initialLayerTemperature,
-        "buildPlateTemperature": setting.buildPlateTemperature,
-        "retractionDistance": setting.retractionDistance,
-        "retractionSpeed": setting.retractionSpeed,
-        "maxRetractionCount": setting.maxRetractionCount,
-        "printer": setting.printer[0].printer,
-        "filament": setting.filament[0].filament
-      }
-    })
-    */  
+
     const setting = allSettings.map((setting) => setting.get( {setting: true }));
 
     const settingArr = setting.map((setting) => {
@@ -51,13 +30,11 @@ router.get('/', withAuth, async (req, res) => {
         "printerModel": setting.printer.dataValues.model,
         "filamentManufacturer": setting.filament.dataValues.manufacturer,
         "filamentColor": setting.filament.dataValues.color,
-        "filamentDiameter": setting.filament.dataValues.diameter
-        //"materialType": setting.material.dataValues.materialType
+        "filamentDiameter": setting.filament.dataValues.diameter,
+        "materialType": materialsArr[setting.filament.dataValues.materialId-1]
       }
     })
-      //setting.get({ setting: true }));
 
-    //console.log(settings, "this is line 24");
     res.render('settings', { settingArr });
     
   } catch (error) {

--- a/views/settings.handlebars
+++ b/views/settings.handlebars
@@ -1,14 +1,38 @@
+<table class="table">
+    <thead>
+        <tr>
+            <th scope="col">Manufacturer</th>
+            <th scope="col">Color</th>
+            <th scope="col">Material</th>
+            <th scope="col">Diameter</th>
+            <th scope="col">Printer Name</th>
+            <th scope="col">Print Temperature</th>
+            <th scope="col">Layer Temperature</th>
+            <th scope="col">Build Plate Temperature</th>
+            <th scope="col">Retraction Distance</th>
+            <th scope="col">Retraction Speed</th>
+            <th scope="col">Max Retraction Count</th>      
+
+        </tr>
+    </thead>
+    <tbody>
 {{#each settingArr as | setting |}}
-    <li>
-       Printer Name: {{setting.printerName}}<br>
-       Print Temperature: {{setting.printTemperature}}<br>
-       Layer Temperature: {{setting.initialLayerTemperature}}<br>
-       Build Temperature: {{setting.buildPlateTemperature}}<br>
-       Retraction Distance: {{setting.retractionDistance}}<br>
-       Retraction Speed: {{setting.retractionSpeed}}<br>
-       Max Retraction Count: {{setting.maxRetractionCount}}<br>       
-    </li>
+        <tr>
+            <td>{{setting.filamentManufacturer}}</td>
+            <td>{{setting.filamentColor}}</td>
+            <td>{{setting.materialType}}</td>
+            <td>{{setting.filamentDiameter}}</td>
+            <td>{{setting.printerName}}</td>
+            <td>{{setting.printTemperature}}</td>
+            <td>{{setting.initialLayerTemperature}}</td>
+            <td>{{setting.buildPlateTemperature}}</td>
+            <td>{{setting.retractionDistance}}</td>
+            <td>{{setting.retractionSpeed}}</td>
+            <td>{{setting.maxRetractionCount}}</td>
+        </tr>
 {{/each}}
+    </tbody>
+</table>
 {{#if logged_in}}
     <script src="/js/logout.js"></script>
 {{/if}}


### PR DESCRIPTION
Reformat the settings.handlebar render from a list to a table. 
Add a second query to the route for the material types and include the material type in the settings map