### PR TITLE
Do filament and printer queries on setting route

### DIFF
--- a/controllers/api/settingRoutes.js
+++ b/controllers/api/settingRoutes.js
@@ -38,10 +38,26 @@ router.get('/', withAuth, async (req, res) => {
       }
     })
 
+    const printerData = await Printer.findAll({
+      where: {
+        userId: req.session.user_id
+      }
+    });
+
+    const filamentData = await Filament.findAll({
+      where: {
+        userId: req.session.user_id
+      }
+    })
+
+    const printers = printerData.map((printer) => printer.get( {printer: true} ));
+    const filaments = filamentData.map((filament) => filament.get( {filament: true }));
+    
+
     res.render('settings', { 
       settingArr,
-      printers: req.session.printers,
-      filaments: req.session.filaments,
+      printers,
+      filaments,
       logged_in: req.session.logged_in 
     });
     

--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -53,13 +53,13 @@ router.get('/profile', withAuth, async (req, res) => {
     const user = userData.get({ plain: true });
     const printers = printerData.map((printer) => printer.get( {printer: true} ));
     const filaments = filamentData.map((filament) => filament.get( {filament: true }));
-
+    /*
     req.session.save(() => {
       req.session.printers = printers;
       req.session.filaments = filaments;
 
     });
-
+    */
     res.render('profile', {
       ...user,
       printers, 


### PR DESCRIPTION
Change printer and filament in the setting route to be new queries instead of data saved in session storage by the profile route.